### PR TITLE
Add perfdash ppc64le changes

### DIFF
--- a/perfdash/Dockerfile
+++ b/perfdash/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM quay.io/powercloud/debian:stable
 RUN apt-get update
 RUN apt-get install -y -qq ca-certificates
 ADD perfdash /perfdash

--- a/perfdash/README.md
+++ b/perfdash/README.md
@@ -47,3 +47,8 @@ short while for perfdash to start since it needs to fetch the job artifacts firs
 
 You can alter startup parameters (like number of jobs for which history is fetched)
 by editing the makefile.
+
+## How to build the perfdash image
+
+* `make perfdash` - This will generate a perfdash executable file in the perfdash directory
+* `docker build -t quay.io/powercloud/perfdash:latest -f ./Dockerfile --no-cache .`

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.32
+        image: quay.io/powercloud/perfdash:latest
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
- perfdash Dockerfile and deployment template update.
- perfdash README.md update to add image build instructions
- Working perfdash and debian images created and pushed to powercloud and referenced in above files.
`quay.io/powercloud/debian:stable`
`quay.io/powercloud/perfdash:latest`